### PR TITLE
refactor: integrate localizePath into all home page navigation links …

### DIFF
--- a/src/components/pages/home/components/HeroContent.tsx
+++ b/src/components/pages/home/components/HeroContent.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from "@/i18n/LanguageContext";
 import HeroServiceIcons from "./HeroServiceIcons";
 
 export default function HeroContent() {
-  const { t, lang } = useLanguage();
+  const { t, lang, localizePath } = useLanguage();
   const isRTL = lang === "ar";
 
   return (
@@ -60,7 +60,7 @@ export default function HeroContent() {
         >
           {/* Primary CTA */}
           <Link
-            href="/#contact"
+            href={localizePath("/#contact")}
             className="group inline-flex w-full sm:w-[220px] h-14 items-center justify-center gap-2 rounded-full bg-gradient-to-r from-purple-600 to-pink-500 px-6 sm:px-8 text-[15px] sm:text-base font-semibold text-white shadow-lg shadow-purple-500/30 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-purple-500/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 active:translate-y-0 whitespace-nowrap"
           >
             <svg
@@ -81,7 +81,7 @@ export default function HeroContent() {
 
           {/* Secondary CTA */}
           <Link
-            href="/#visual-examples"
+            href={localizePath("/#visual-examples")}
             className="group inline-flex w-full sm:w-[220px] h-14 items-center justify-center gap-2 rounded-full border-2 border-purple-500 bg-white/85 px-6 sm:px-8 text-[15px] sm:text-base font-semibold text-purple-700 backdrop-blur-sm transition-all duration-300 hover:bg-purple-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 whitespace-nowrap"
           >
             <svg

--- a/src/components/pages/home/components/MonthlyPlanCard.tsx
+++ b/src/components/pages/home/components/MonthlyPlanCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { useLanguage } from "@/i18n/LanguageContext";
 import { TPlanMeta } from "@/content/home/pricing";
 
 const itemVariants = {
@@ -16,6 +17,8 @@ type Props = {
 };
 
 export default function MonthlyPlanCard({ plan, description, features, ctaText }: Props) {
+  const { localizePath } = useLanguage();
+
   return (
     <motion.div
       variants={itemVariants}
@@ -49,7 +52,7 @@ export default function MonthlyPlanCard({ plan, description, features, ctaText }
       </ul>
 
       <a
-        href="/#contact"
+        href={localizePath("/#contact")}
         className={`w-full block text-center bg-gradient-to-r ${plan.color} text-white font-bold py-4 px-6 rounded-xl transition-all duration-300 hover:shadow-lg hover:-translate-y-1`}
       >
         {ctaText}

--- a/src/components/pages/home/components/StickyDesktopCTA.tsx
+++ b/src/components/pages/home/components/StickyDesktopCTA.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from "@/i18n/LanguageContext";
 type Props = { isVisible: boolean };
 
 export default function StickyDesktopCTA({ isVisible }: Props) {
-  const { t, lang } = useLanguage();
+  const { t, lang, localizePath } = useLanguage();
   const isRTL = lang === "ar";
   const arrowPath = isRTL ? "M15 5l-7 7 7 7" : "M9 5l7 7-7 7";
 
@@ -22,7 +22,7 @@ export default function StickyDesktopCTA({ isVisible }: Props) {
       aria-hidden={!isVisible}
     >
       <Link
-        href="/#contact"
+        href={localizePath("/#contact")}
         className={`group relative flex items-center gap-3 py-3.5 bg-[#1a2744] text-white font-semibold text-sm shadow-xl shadow-[#1a2744]/30 hover:shadow-2xl hover:shadow-[#1a2744]/40 transition-all duration-300 ${isRTL
             ? "rounded-r-full pr-5 pl-4 hover:pr-7"
             : "rounded-l-full pl-5 pr-4 hover:pl-7"

--- a/src/components/pages/home/components/StickyMobileCTA.tsx
+++ b/src/components/pages/home/components/StickyMobileCTA.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from "@/i18n/LanguageContext";
 type Props = { isVisible: boolean };
 
 export default function StickyMobileCTA({ isVisible }: Props) {
-  const { t } = useLanguage();
+  const { t, localizePath } = useLanguage();
 
   return (
     <div
@@ -19,14 +19,14 @@ export default function StickyMobileCTA({ isVisible }: Props) {
       <div className="bg-white/95 backdrop-blur-xl border border-purple-100 shadow-2xl shadow-purple-500/20 rounded-2xl p-2">
         <div className="flex gap-2">
           <Link
-            href="/#contact"
+            href={localizePath("/#contact")}
             className="flex-1 text-center px-4 py-3 rounded-xl text-white bg-gradient-to-r from-purple-600 to-pink-500 font-semibold text-sm shadow-lg shadow-purple-500/30"
           >
             {t.hero.stickyConsultation}
           </Link>
 
           <Link
-            href="/#visual-examples"
+            href={localizePath("/#visual-examples")}
             className="flex-1 text-center px-4 py-3 rounded-xl bg-white border-2 border-purple-200 text-purple-600 font-semibold text-[13px]"
           >
             {t.hero.stickyPortfolio}

--- a/src/components/pages/home/components/WebsitePricingCard.tsx
+++ b/src/components/pages/home/components/WebsitePricingCard.tsx
@@ -9,7 +9,7 @@ const itemVariants = {
 };
 
 export default function WebsitePricingCard() {
-  const { t } = useLanguage();
+  const { t, localizePath } = useLanguage();
   const w = t.pricing.websiteDev;
 
   return (
@@ -84,7 +84,7 @@ export default function WebsitePricingCard() {
 
           {/* CTA Button */}
           <a
-            href="/#contact"
+            href={localizePath("/#contact")}
             className="w-[280px] block text-center bg-gradient-to-r from-[#C084FC] to-[#818CF8] text-white text-[16px] font-bold py-4 px-6 rounded-xl transition-all duration-300 hover:shadow-lg hover:-translate-y-1"
           >
             {w.ctaText}

--- a/src/components/pages/home/sections/PlansSection.tsx
+++ b/src/components/pages/home/sections/PlansSection.tsx
@@ -18,7 +18,7 @@ const itemVariants = {
 };
 
 const PlansSection = () => {
-  const { t } = useLanguage();
+  const { t, localizePath } = useLanguage();
 
   return (
     <section
@@ -93,7 +93,7 @@ const PlansSection = () => {
                 </p>
               </div>
               <a
-                href="/#contact"
+                href={localizePath("/#contact")}
                 className="w-[312px] shrink-0 text-center bg-gradient-to-r from-[#9333EB] to-[#EC4899] text-white font-bold text-lg py-4 rounded-xl transition-all duration-300 hover:shadow-lg hover:-translate-y-1 whitespace-nowrap"
               >
                 {t.pricing.customizePlan.ctaText}


### PR DESCRIPTION
…for proper i18n routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation and call-to-action links throughout the application now properly respect language and region localization settings. Contact form anchors, pricing section call-to-action buttons, hero section navigation links, and sticky navigation menu elements correctly route to language-specific destinations, ensuring consistent user experiences when navigating between sections in your preferred language or region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->